### PR TITLE
react/no-unused-prop-types in warning mode

### DIFF
--- a/index.js
+++ b/index.js
@@ -95,6 +95,7 @@ module.exports = {
     'react/no-did-mount-set-state': 0,
     'react/no-did-update-set-state': 0,
     'react/no-multi-comp': 0,
+    'react/no-unused-prop-types': 1,
     'react/prefer-es6-class': 2,
     'react/prefer-stateless-function': 0,
     'react/prop-types': 0,


### PR DESCRIPTION
Put react/no-unused-prop-types in warning mode (1).
The doc of this rule is available here : https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-unused-prop-types.md


Putting in warning due to false positive when I define a function in my PropTypes to throw error when the others PropTypes doesn't match each others.

Example: 

```
Dropdown.propTypes = {
  handleValue: function(props) {
    if (props['value'] && props['options'].indexOf(props['value']) === -1) {
      return new Error(
        'Value ' + props['value'] + ' is not contained in options [' + props['options'] + ']',
      )
    }
  },
  options: PropTypes.arrayOf(PropTypes.string).isRequired,
  value: PropTypes.string,
}
```

Here, the handleValue prop is checking than the Prop value is contained in Prop options.
handleValue will be reported as never used by this rule.