### PR TITLE
fix dependency URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Install the package:
 
 ```bash
-$ yarn add git+ssh://git@github.com:derniercri/eslint-config-derniercri.git
+$ yarn add git+https://git@github.com:derniercri/eslint-config-derniercri.git
 ```
 
 Create or edit a `.eslintrc` file at project's root :

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Install the package:
 
 ```bash
-$ yarn add git+https://git@github.com:derniercri/eslint-config-derniercri.git
+$ yarn add git+https://git@github.com/derniercri/eslint-config-derniercri.git
 ```
 
 Create or edit a `.eslintrc` file at project's root :


### PR DESCRIPTION
Update dependency URL from **git+ssh** to **git+https** As repository has been made public.