### PR TITLE
:wrench: declare React version dynamically

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,5 +10,10 @@ module.exports = {
     'jsx-boolean-value': 0,
     'jsx-no-lambda': 0,
     'newline-before-return': 1
+  },
+  settings: {
+    react: {
+      version: "detect"
+    }
   }
 }


### PR DESCRIPTION
Avoid warning:
> Warning: React version not specified in eslint-plugin-react settings. See https://github.com/yannickcr/eslint-plugin-react#configuration .